### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ bong: a simple timer
 .. image:: https://travis-ci.org/prophile/bong.svg
     :target: https://travis-ci.org/prophile/bong
 
-.. image:: https://pypip.in/version/bong/badge.svg
+.. image:: https://img.shields.io/pypi/v/bong.svg
     :target: https://pypi.python.org/pypi/bong/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20bong))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `bong`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.